### PR TITLE
Fix for display corruption on GLK19264A

### DIFF
--- a/server/drivers/glk.c
+++ b/server/drivers/glk.c
@@ -529,7 +529,7 @@ glk_backlight(Driver *drvthis, int on)
 		debug(RPT_DEBUG, "Backlight ON");
 		glkputl(p->fd, GLKCommand, 0x42, 0, EOF);
 		debug(RPT_DEBUG, "Brightness 255");
-		glkputl(p->fd, GLKCommand, 0x98, 255, EOF);
+		glkputl(p->fd, GLKCommand, 0x99, 255, EOF);
 	}
 	else {
 		debug(RPT_DEBUG, "Backlight OFF");


### PR DESCRIPTION
In some cases, the set and save brightness command would cause corruption on the GLK19264A USB display (see picture), changing to set brightness without saving command.

![2014-11-24 15 53 13](https://cloud.githubusercontent.com/assets/3372394/5182871/cdadb44e-749f-11e4-81cc-f2c7efe41c96.jpg)
